### PR TITLE
🐛 BUG: numbered nested toctrees were unordered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist/
 _build/
 _static
 _templates
+.DS_Store
 
 
 # Unit test / coverage reports

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # sphinx-multitoc-numbering
 
+[![Documentation Status][rtd-badge]][rtd-link]
 [![Github-CI][github-ci]][github-link]
 [![Coverage Status][codecov-badge]][codecov-link]
 
@@ -23,10 +24,16 @@ extensions = ["sphinx_multitoc_numbering"]
 ...
 ```
 
+## Documentation
+
+See the [sphinx-multitoc-numbering documentation](https://sphinx-multitoc-numbering.readthedocs.io/en/latest/) for more information.
+
 ## Contributing
 
 We welcome all contributions! See the [EBP Contributing Guide](https://executablebooks.org/en/latest/contributing.html) for general details.
 
+[rtd-badge]: https://readthedocs.org/projects/sphinx-multitoc-numbering/badge/?version=latest
+[rtd-link]: https://sphinx-multitoc-numbering.readthedocs.io/en/latest/?badge=latest
 [github-ci]: https://github.com/executablebooks/sphinx-multitoc-numbering/workflows/continuous-integration/badge.svg?branch=master
 [github-link]: https://github.com/executablebooks/sphinx-multitoc-numbering
 [codecov-badge]: https://codecov.io/gh/executablebooks/sphinx-multitoc-numbering/branch/master/graph/badge.svg

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -82,7 +82,7 @@ PART2
 ```
 
 
-# Inspiration
+## Inspiration
 
 The development of `sphinx-multitoc-numbering` was mostly inspired from the discussions in this sphinx issue's [thread](https://github.com/sphinx-doc/sphinx/issues/3357).
 

--- a/sphinx_multitoc_numbering/__init__.py
+++ b/sphinx_multitoc_numbering/__init__.py
@@ -98,7 +98,13 @@ def assign_section_numbers(self, env: BuildEnvironment) -> List[str]:
                 if secnums != old_secnumbers.get(ref):
                     rewrite_needed.append(ref)
 
-    for docname in env.numbered_toctrees:
+    # rearrange it to respect ordering in toctree directives
+    rearranged_numbered_toctrees = []
+    for toc in env.tocs:
+        if toc in env.numbered_toctrees:
+            rearranged_numbered_toctrees.append(toc)
+
+    for docname in rearranged_numbered_toctrees:
         assigned.add(docname)
         doctree = env.get_doctree(docname)
         for toctreenode in doctree.traverse(addnodes.toctree):

--- a/tests/roots/test-nested-toctree/Makefile
+++ b/tests/roots/test-nested-toctree/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/tests/roots/test-nested-toctree/conf.py
+++ b/tests/roots/test-nested-toctree/conf.py
@@ -1,0 +1,51 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = "sphinx-multitoc-numbering"
+copyright = "2020, Cristian G Guerrero"
+author = "Cristian G Guerrero"
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = ["sphinx_multitoc_numbering"]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "alabaster"
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]

--- a/tests/roots/test-nested-toctree/index.rst
+++ b/tests/roots/test-nested-toctree/index.rst
@@ -1,0 +1,24 @@
+.. sphinx-multitoc-numbering / Issue #14 Reproducer documentation master file, created by
+   sphinx-quickstart on Wed Oct 21 12:22:53 2020.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to sphinx-multitoc-numbering / Issue #14 Reproducer's documentation!
+============================================================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   unumbered_chapter
+   part1/index
+   part2/index
+   part3/index
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/tests/roots/test-nested-toctree/make.bat
+++ b/tests/roots/test-nested-toctree/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/tests/roots/test-nested-toctree/part1/chapter1.rst
+++ b/tests/roots/test-nested-toctree/part1/chapter1.rst
@@ -1,0 +1,5 @@
+*********
+Chapter 1
+*********
+
+The contents

--- a/tests/roots/test-nested-toctree/part1/chapter2.rst
+++ b/tests/roots/test-nested-toctree/part1/chapter2.rst
@@ -1,0 +1,5 @@
+*********
+Chapter 2
+*********
+
+The contents

--- a/tests/roots/test-nested-toctree/part1/index.rst
+++ b/tests/roots/test-nested-toctree/part1/index.rst
@@ -1,0 +1,9 @@
+######
+Part 1
+######
+
+.. toctree::
+    :numbered:
+
+    chapter1
+    chapter2

--- a/tests/roots/test-nested-toctree/part2/chapter3.rst
+++ b/tests/roots/test-nested-toctree/part2/chapter3.rst
@@ -1,0 +1,5 @@
+*********
+Chapter 3
+*********
+
+The contents

--- a/tests/roots/test-nested-toctree/part2/index.rst
+++ b/tests/roots/test-nested-toctree/part2/index.rst
@@ -1,0 +1,8 @@
+######
+Part 2
+######
+
+.. toctree::
+    :numbered:
+
+    chapter3

--- a/tests/roots/test-nested-toctree/part3/chapter4.rst
+++ b/tests/roots/test-nested-toctree/part3/chapter4.rst
@@ -1,0 +1,5 @@
+*********
+Chapter 4
+*********
+
+The contents

--- a/tests/roots/test-nested-toctree/part3/index.rst
+++ b/tests/roots/test-nested-toctree/part3/index.rst
@@ -1,0 +1,8 @@
+######
+Part 3
+######
+
+.. toctree::
+    :numbered:
+
+    chapter4

--- a/tests/roots/test-nested-toctree/unumbered_chapter.rst
+++ b/tests/roots/test-nested-toctree/unumbered_chapter.rst
@@ -1,0 +1,5 @@
+*****************
+Unumbered Chapter
+*****************
+
+The contents

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -44,3 +44,18 @@ def test_mixed(app, file_regression):
     assert "2. Chapter 2" in str(toctree_wrapper)
     assert ">Part 2" in str(toctree_wrapper)
     assert ">Chapter 3" in str(toctree_wrapper)
+
+
+@pytest.mark.sphinx("html", testroot="nested-toctree")
+def test_nested(app, file_regression):
+    app.build()
+    outfile = app.outdir / "index.html"
+
+    # get content markup
+    soup = bs(outfile.read_text(encoding="utf8"), "html.parser")
+    toctree_wrapper = soup.findAll("div", {"class": "toctree-wrapper"})[0]
+    file_regression.check(toctree_wrapper.prettify(), extension=".html")
+    assert "1. Chapter 1" in str(toctree_wrapper)
+    assert "2. Chapter 2" in str(toctree_wrapper)
+    assert "3. Chapter 3" in str(toctree_wrapper)
+    assert "4. Chapter 4" in str(toctree_wrapper)

--- a/tests/test_build/test_nested.html
+++ b/tests/test_build/test_nested.html
@@ -1,0 +1,55 @@
+<div class="toctree-wrapper compound">
+ <p class="caption">
+  <span class="caption-text">
+   Contents:
+  </span>
+ </p>
+ <ul>
+  <li class="toctree-l1">
+   <a class="reference internal" href="unumbered_chapter.html">
+    Unumbered Chapter
+   </a>
+  </li>
+  <li class="toctree-l1">
+   <a class="reference internal" href="part1/index.html">
+    Part 1
+   </a>
+   <ul>
+    <li class="toctree-l2">
+     <a class="reference internal" href="part1/chapter1.html">
+      1. Chapter 1
+     </a>
+    </li>
+    <li class="toctree-l2">
+     <a class="reference internal" href="part1/chapter2.html">
+      2. Chapter 2
+     </a>
+    </li>
+   </ul>
+  </li>
+  <li class="toctree-l1">
+   <a class="reference internal" href="part2/index.html">
+    Part 2
+   </a>
+   <ul>
+    <li class="toctree-l2">
+     <a class="reference internal" href="part2/chapter3.html">
+      3. Chapter 3
+     </a>
+    </li>
+   </ul>
+  </li>
+  <li class="toctree-l1">
+   <a class="reference internal" href="part3/index.html">
+    Part 3
+   </a>
+   <ul>
+    <li class="toctree-l2">
+     <a class="reference internal" href="part3/chapter4.html">
+      4. Chapter 4
+     </a>
+    </li>
+   </ul>
+  </li>
+ </ul>
+</div>


### PR DESCRIPTION
fixes https://github.com/executablebooks/sphinx-multitoc-numbering/issues/14

Thanks, @guyikcgg for the issue. Also, is it fine if I steal your [test repo](https://github.com/guyikcgg/sphinx-multitoc-numbering-issue14) for this bug as a test case for this repo? :P. Have kept your name as the author. 

Probably it would be better though I think if you send a PR with that test folder?