### PR TITLE
Include LICENSE in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,5 @@ setup(
             "myst-parser",
         ],
     },
+    include_package_data=True,
 )


### PR DESCRIPTION
Thanks for this tool!

This PR adds the LICENSE to the source distribution, which is nice for downstreams... presently working on a conda-forge feedstock for this package, which requires license info for everything (even if the license doesn't _require_ it to be compliant).