### PR TITLE
👌 IMPROVE: Extension loading message

### DIFF
--- a/sphinx_multitoc_numbering/__init__.py
+++ b/sphinx_multitoc_numbering/__init__.py
@@ -22,6 +22,12 @@ __version__ = "0.1.2"
 """sphinx-multitoc-numbering version"""
 
 
+def build_init_handler(app):
+    from sphinx.util.console import bold
+
+    logger.info(bold("sphinx-multitoc-numbering v%s:") + " Loaded", __version__)
+
+
 def assign_section_numbers(self, env: BuildEnvironment) -> List[str]:
     """Assign a section number to each heading under a numbered toctree."""
     # a list of all docnames whose section numbers changed
@@ -120,4 +126,5 @@ def assign_section_numbers(self, env: BuildEnvironment) -> List[str]:
 def setup(app):
     from sphinx.environment.collectors.toctree import TocTreeCollector
 
+    app.connect("builder-inited", build_init_handler)
     TocTreeCollector.assign_section_numbers = assign_section_numbers


### PR DESCRIPTION
Have logged a message in the console stating the version for better visibility of this extension.

The message looks like the following:

<img width="369" alt="Screen Shot 2021-03-01 at 12 26 30 pm" src="https://user-images.githubusercontent.com/6542997/109441427-5c257900-7a89-11eb-8695-f3368de58763.png">


